### PR TITLE
Made appdmg optional for cross-platform compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "electron-prebuilt": "1.2.8"
   },
   "devDependencies": {
-    "electron-packager": "^7.2.0",
+    "electron-packager": "^7.2.0"
+  },
+  "optionalDependencies": {
     "appdmg": "^0.4.0"
   }
 }


### PR DESCRIPTION
appdmg is only available on OS X. This change allowed me to build Lectrote on Ubuntu. I think this change is necessary on Windows as well.