### PR TITLE
Amend 'Hide Others' binding for Mac

### DIFF
--- a/main.js
+++ b/main.js
@@ -1251,7 +1251,7 @@ function construct_menu_template(special)
             },
             {
                 label: 'Hide Others',
-                accelerator: 'Command+Shift+H',
+                accelerator: 'Command+Alt+H',
                 role: 'hideothers'
             },
             {


### PR DESCRIPTION
Use platform default ⌥⌘H (rather than ⌘⇧H)